### PR TITLE
Include clusterversion resource in gather scripts

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -26,6 +26,9 @@ ANSIBLECRD="automationcontrollerbackups.automationcontroller.ansible.com \
 oc adm inspect customresourcedefinition.apiextensions.k8s.io $ANSIBLECRD --dest-dir=must-gather
 oc adm inspect customresourcedefinition.apiextensions.k8s.io subscriptions.operators.coreos.com clusterserviceversions.operators.coreos.com --dest-dir=must-gather
 
+oc adm inspect clusterversion --dest-dir=must-gather
+oc adm inspect customresourcedefinition clusterversions.config.openshift.io --dest-dir=must-gather
+
 for i in $ANSIBLECRD; do
    oc adm inspect $i --all-namespaces --dest-dir=must-gather 
    ANSIBLENS+=`oc get $i --all-namespaces --no-headers=true -o custom-columns=NAMESPACE:.metadata.namespace; echo " "`

--- a/collection-scripts/ns-gather
+++ b/collection-scripts/ns-gather
@@ -26,6 +26,9 @@ ANSIBLECRD="automationcontrollerbackups.automationcontroller.ansible.com \
 oc adm inspect customresourcedefinition.apiextensions.k8s.io $ANSIBLECRD --dest-dir=must-gather
 oc adm inspect customresourcedefinition.apiextensions.k8s.io subscriptions.operators.coreos.com clusterserviceversions.operators.coreos.com --dest-dir=must-gather
 
+oc adm inspect clusterversion --dest-dir=must-gather
+oc adm inspect customresourcedefinition clusterversions.config.openshift.io --dest-dir=must-gather
+
 for i in $ANSIBLECRD; do
   oc adm inspect $i -n $1 --dest-dir=must-gather
 done


### PR DESCRIPTION
Include clusterversion resource for additional information about the cluster in gather scripts, and the CRD for being able to use with `omg`/`omc`.

It will allow to show the version of the cluster, and the OpenShift `clusterID` in AAP must-gather files:
~~~
$ omc get clusterversion
NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.15.16   True        False         37h     Cluster version is 4.15.16

$ omc get clusterversion -o yaml | grep clusterID
    clusterID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
~~~