### PR TITLE
feat: collect events and previous container logs

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -45,6 +45,29 @@ for a in $NS; do
   oc adm inspect ns/"$a"  --dest-dir=must-gather
   oc adm inspect -n $a csv --dest-dir=must-gather
   oc get pods -n $a >> ${BASE_COLLECTION_PATH}/gather-aap.log
+
+  # Collect events sorted by timestamp
+  EVENTS_DIR="${BASE_COLLECTION_PATH}/namespaces/${a}/events"
+  mkdir -p "${EVENTS_DIR}"
+  oc get events -n "$a" --sort-by=.lastTimestamp > "${EVENTS_DIR}/events_all.txt" 2>/dev/null || true
+  oc get events -n "$a" --field-selector type=Warning --sort-by=.lastTimestamp > "${EVENTS_DIR}/events_warnings.txt" 2>/dev/null || true
+
+  # Collect previous container logs for restarted pods
+  PREV_LOG_PATH="${BASE_COLLECTION_PATH}/namespaces/${a}/previous-logs"
+  mkdir -p "${PREV_LOG_PATH}"
+  PODS=$(oc get pods -n "$a" --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null)
+  for pod in $PODS; do
+    CONTAINERS=$(oc get pod "$pod" -n "$a" -o jsonpath='{.spec.containers[*].name}' 2>/dev/null)
+    for container in $CONTAINERS; do
+      oc logs "$pod" -n "$a" -c "$container" --previous \
+        > "${PREV_LOG_PATH}/${pod}_${container}_previous.log" 2>/dev/null || true
+    done
+    INIT_CONTAINERS=$(oc get pod "$pod" -n "$a" -o jsonpath='{.spec.initContainers[*].name}' 2>/dev/null)
+    for container in $INIT_CONTAINERS; do
+      oc logs "$pod" -n "$a" -c "$container" --previous \
+        > "${PREV_LOG_PATH}/${pod}_init_${container}_previous.log" 2>/dev/null || true
+    done
+  done
 done
 
 for b in $(oc get -A subs --field-selector='metadata.name=ansible-automation-platform-operator' -o custom-columns=NAMESPACE:.metadata.namespace); do

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -78,6 +78,37 @@ fi
 oc adm inspect customresourcedefinition.apiextensions.k8s.io $CRDS_TO_COLLECT --dest-dir=must-gather
 oc adm inspect customresourcedefinition.apiextensions.k8s.io subscriptions.operators.coreos.com clusterserviceversions.operators.coreos.com --dest-dir=must-gather
 
+# collect_events <namespace>
+collect_events() {
+  local ns="$1"
+  EVENTS_DIR="${BASE_COLLECTION_PATH}/namespaces/${ns}/events"
+  mkdir -p "${EVENTS_DIR}"
+  oc get events -n "$ns" --sort-by=.lastTimestamp > "${EVENTS_DIR}/events_all.txt" 2>/dev/null || true
+  oc get events -n "$ns" --field-selector type=Warning --sort-by=.lastTimestamp > "${EVENTS_DIR}/events_warnings.txt" 2>/dev/null || true
+}
+
+# collect_previous_logs <namespace>
+collect_previous_logs() {
+  local ns="$1"
+  PREV_LOG_PATH="${BASE_COLLECTION_PATH}/namespaces/${ns}/previous-logs"
+  mkdir -p "${PREV_LOG_PATH}"
+  PODS=$(oc get pods -n "$ns" --no-headers -o custom-columns=NAME:.metadata.name 2>/dev/null)
+  for pod in $PODS; do
+    CONTAINERS=$(oc get pod "$pod" -n "$ns" -o jsonpath='{.spec.containers[*].name}' 2>/dev/null)
+    for container in $CONTAINERS; do
+      oc logs "$pod" -n "$ns" -c "$container" --previous \
+        > "${PREV_LOG_PATH}/${pod}_${container}_previous.log" 2>/dev/null || \
+        rm -f "${PREV_LOG_PATH}/${pod}_${container}_previous.log"
+    done
+    INIT_CONTAINERS=$(oc get pod "$pod" -n "$ns" -o jsonpath='{.spec.initContainers[*].name}' 2>/dev/null)
+    for container in $INIT_CONTAINERS; do
+      oc logs "$pod" -n "$ns" -c "$container" --previous \
+        > "${PREV_LOG_PATH}/${pod}_init_${container}_previous.log" 2>/dev/null || \
+        rm -f "${PREV_LOG_PATH}/${pod}_init_${container}_previous.log"
+    done
+  done
+}
+
 if [[ -n "$NAMESPACE" ]]; then
   for i in $CRDS_TO_COLLECT; do
     oc adm inspect $i -n $NAMESPACE --dest-dir=must-gather
@@ -85,6 +116,8 @@ if [[ -n "$NAMESPACE" ]]; then
 
   oc adm inspect ns/"$NAMESPACE"  --dest-dir=must-gather
   oc get pods -n $NAMESPACE >> ${BASE_COLLECTION_PATH}/gather-aap.log
+  collect_events "$NAMESPACE"
+  collect_previous_logs "$NAMESPACE"
 else
   for i in $CRDS_TO_COLLECT; do
      oc adm inspect $i --all-namespaces --dest-dir=must-gather
@@ -97,6 +130,8 @@ else
     oc adm inspect ns/"$a"  --dest-dir=must-gather
     oc adm inspect -n $a csv --dest-dir=must-gather
     oc get pods -n $a >> ${BASE_COLLECTION_PATH}/gather-aap.log
+    collect_events "$a"
+    collect_previous_logs "$a"
   done
 
   for b in $(oc get -A subs --field-selector='metadata.name=ansible-automation-platform-operator' -o custom-columns=NAMESPACE:.metadata.namespace); do

--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -99,11 +99,15 @@ collect_previous_logs() {
       oc logs "$pod" -n "$ns" -c "$container" --previous \
         > "${PREV_LOG_PATH}/${pod}_${container}_previous.log" 2>/dev/null || \
         rm -f "${PREV_LOG_PATH}/${pod}_${container}_previous.log"
+      [ -s "${PREV_LOG_PATH}/${pod}_${container}_previous.log" ] || \
+        rm -f "${PREV_LOG_PATH}/${pod}_${container}_previous.log"
     done
     INIT_CONTAINERS=$(oc get pod "$pod" -n "$ns" -o jsonpath='{.spec.initContainers[*].name}' 2>/dev/null)
     for container in $INIT_CONTAINERS; do
       oc logs "$pod" -n "$ns" -c "$container" --previous \
         > "${PREV_LOG_PATH}/${pod}_init_${container}_previous.log" 2>/dev/null || \
+        rm -f "${PREV_LOG_PATH}/${pod}_init_${container}_previous.log"
+      [ -s "${PREV_LOG_PATH}/${pod}_init_${container}_previous.log" ] || \
         rm -f "${PREV_LOG_PATH}/${pod}_init_${container}_previous.log"
     done
   done


### PR DESCRIPTION
## Summary

Add event collection and previous container log capture to the gather script.

- **Events**: sorted by `.lastTimestamp` (all events + warning-only filter) per AAP namespace
- **Previous logs**: captures `--previous` logs for all containers in restarted pods, silently skipping pods that haven't restarted

## Test plan

Tested against a live AAP 2.6 cluster:
- [x] Events collected: 10 events in `events_all.txt`, 3 warnings in `events_warnings.txt`
- [x] Previous logs captured: 18 files (213K total lines) from restarted containers
- [x] Non-restarted pods handled gracefully (no errors, no empty files in output)
- [x] No changes to existing `oc adm inspect` output structure

Closes #22
Closes #23

Co-authored-by: David L.