### PR TITLE
fix: run container as non-root to satisfy restricted-v2 SCC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,6 @@ COPY --from=builder /usr/bin/oc /usr/bin/oc
 # copy all collection scripts to /usr/bin
 COPY collection-scripts/* /usr/bin/
 
+USER 1001
+
 ENTRYPOINT /usr/bin/gather


### PR DESCRIPTION
The gather script only makes Kubernetes API calls via oc and does not
need local root privileges. Setting USER 1001 allows the pod to run
with runAsNonRoot: true.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
