### PR TITLE
docs: correct README terminology from operator to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AAP Must Gather
 
-This is a must gather operator for Ansible Automation Platform.
+This is a must-gather plugin for Ansible Automation Platform, used with `oc adm must-gather`.
 
 ## Purpose
 
-The purpose of this operator is to gather debugging 
+The purpose of this plugin is to gather debugging 
 
 ## Usage
 


### PR DESCRIPTION
## What

Corrected README to describe the project as a "must-gather plugin" instead of
"must gather operator." This is not an operator — it has no CRDs, controllers,
or reconciliation loops. It is a must-gather plugin image consumed by
`oc adm must-gather --image=`.

## Why

The README inaccurately described the project as an operator, which could
confuse contributors and users about the project's architecture.

## Test plan

- [x] Verified README wording is accurate against Dockerfile and collection scripts

Assisted-by: Claude Code / Opus 4.6 (Anthropic)
